### PR TITLE
Reworking leap year calculation

### DIFF
--- a/date-republicain.js
+++ b/date-republicain.js
@@ -479,7 +479,7 @@ var getRepublicainDate = function (dateInput) {
     rep.year = 1;
 
     while (days >= 0) {
-        var leapYear = (rep.year + 1) % 4 == 0;
+        var leapYear = ((rep.year + 1) % 4 == 0 && (rep.year + 1) % 100 != 0) || (rep.year + 1) % 400 ;
 
         if (days >= (leapYear ? 366 : 365)) {
             rep.year++;


### PR DESCRIPTION
I reworked the leap year calculation to be in accordance to the way it's calculated in the Gregorian system, in order to account for the date drifting caused by the Julian method.

Although this was not defined in the decrees instituting the republican calendar, it seems to be the accepted method for the usage of the republican calendar after year XIX, to prevent date drifting. 

---

For reference :

> Continuous: The leap years would have continued in a fixed rule every four years from the last one (thus years 15, 19, 23, 27...) with the leap day added before, rather than after, each year divisible by four, __except most century years__. This rule has the advantage that it is both simple to calculate and is continuous with every year in which the calendar was in official use during the First Republic. Some concordances were printed in France, after the Republican Calendar was abandoned, using this rule to determine dates for long-term contracts.

From the [English Wikipedia article](https://en.wikipedia.org/wiki/French_Republican_calendar), emphasis mine.

[French Wikipedia article](https://fr.wikipedia.org/wiki/Calendrier_r%C3%A9publicain#Ce_qu'aurait_pu_%C3%AAtre_l'%C3%A9volution_du_calendrier).